### PR TITLE
Add summary comments to AuthInfo class

### DIFF
--- a/webapi/Auth/AuthInfo.cs
+++ b/webapi/Auth/AuthInfo.cs
@@ -12,12 +12,19 @@ namespace CopilotChat.WebApi.Auth;
 /// </summary>
 public class AuthInfo : IAuthInfo
 {
+    /// <summary>
+    /// Record struct to store authenticated user's ID and name.
+    /// </summary>
     private record struct AuthData(
         string UserId,
         string UserName);
 
     private readonly Lazy<AuthData> _data;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AuthInfo"/> class.
+    /// </summary>
+    /// <param name="httpContextAccessor">The HTTP context accessor to retrieve the user's claims.</param>
     public AuthInfo(IHttpContextAccessor httpContextAccessor)
     {
         this._data = new Lazy<AuthData>(() =>


### PR DESCRIPTION
Add summary comments to `AuthInfo.cs` to improve code documentation.

* **AuthData Record Struct**
  - Add a summary comment for the `AuthData` record struct to describe its purpose of storing authenticated user's ID and name.

* **AuthInfo Constructor**
  - Add a summary comment for the `AuthInfo` constructor to describe its purpose and the parameter it takes.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HassanFad/chat-copilot/pull/7?shareId=978786cf-fde1-486a-9e42-05ec8d6017a4).